### PR TITLE
Added pthread for correct build with gtest on linux

### DIFF
--- a/cmake/modules/FindGoogleTest.cmake
+++ b/cmake/modules/FindGoogleTest.cmake
@@ -65,9 +65,14 @@ find_package_handle_standard_args(
         GOOGLEMOCK_INCLUDE_DIR
 )
 
+if(NOT MSVC)
+  set(PThreadLib -pthread)
+endif()
+
 if(GOOGLETEST_FOUND)
     set(
         GOOGLETEST_LIBRARIES
+        ${PThreadLib}
         ${GOOGLETEST_LIBRARY}
         ${GOOGLETEST_MAIN_LIBRARY}
         ${GOOGLEMOCK_LIBRARY}


### PR DESCRIPTION
On linux build error
```
../../deps/googletest/build/googlemock/gtest/libgtest.a(gtest-all.cc.o): In function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::~ThreadLocal()':
gtest-all.cc:(.text._ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED2Ev[_ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED5Ev]+0x24): undefined reference to `pthread_getspecific'
gtest-all.cc:(.text._ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED2Ev[_ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED5Ev]+0x39): undefined reference to `pthread_key_delete'
```